### PR TITLE
Update to work with LTS version 4.14

### DIFF
--- a/kern/compat.h
+++ b/kern/compat.h
@@ -128,7 +128,7 @@ static inline void cr4_clear_bits(unsigned long mask)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0)
 static inline void compat_fpu_restore(void)
 {
-	if (!current->thread.fpu.fpregs_active)
+	if (current->thread.fpu.initialized)
 		fpu__restore(&current->thread.fpu);
 }
 #else

--- a/kern/ept.c
+++ b/kern/ept.c
@@ -750,7 +750,8 @@ static void ept_mmu_notifier_release(struct mmu_notifier *mn,
 }
 
 static const struct mmu_notifier_ops ept_mmu_notifier_ops = {
-	.invalidate_page	= ept_mmu_notifier_invalidate_page,
+	// TODO(alevy): I believe this needs to be converted to `invalidate_range`
+	//.invalidate_page	= ept_mmu_notifier_invalidate_page,
 	.invalidate_range_start	= ept_mmu_notifier_invalidate_range_start,
 	.invalidate_range_end	= ept_mmu_notifier_invalidate_range_end,
 	.clear_flush_young	= ept_mmu_notifier_clear_flush_young,

--- a/kern/preempttrap.c
+++ b/kern/preempttrap.c
@@ -1,3 +1,4 @@
+#include <linux/sched/task_stack.h>
 #include <linux/uaccess.h>
 #include <linux/user-return-notifier.h>
 

--- a/kern/vmx.c
+++ b/kern/vmx.c
@@ -539,7 +539,7 @@ static void vmx_setup_constant_host_state(struct vmx_vcpu *vcpu)
 
 	vmcs_writel(HOST_CR0, read_cr0() & ~X86_CR0_TS);  /* 22.2.3 */
 	vmcs_writel(HOST_CR4, __read_cr4());  /* 22.2.3, 22.2.5 */
-	vmcs_writel(HOST_CR3, read_cr3());  /* 22.2.3 */
+	vmcs_writel(HOST_CR3, read_cr3_pa());  /* 22.2.3 */
 
 	vmcs_write16(HOST_CS_SELECTOR, __KERNEL_CS);  /* 22.2.4 */
 	vmcs_write16(HOST_DS_SELECTOR, __KERNEL_DS);  /* 22.2.4 */
@@ -610,7 +610,7 @@ static unsigned long segment_base(u16 selector)
 	v = get_desc_base(d);
 #ifdef CONFIG_X86_64
        if (d->s == 0 && (d->type == 2 || d->type == 9 || d->type == 11))
-               v |= ((unsigned long)((struct ldttss_desc64 *)d)->base3) << 32;
+               v |= ((unsigned long)((ldt_desc *)d)->base3) << 32;
 #endif
 	return v;
 }
@@ -803,10 +803,9 @@ static u64 construct_eptp(unsigned long root_hpa)
 	u64 eptp;
 
 	/* TODO write the value reading from MSR */
-	eptp = VMX_EPT_DEFAULT_MT |
-		VMX_EPT_DEFAULT_GAW << VMX_EPT_GAW_EPTP_SHIFT;
+	eptp = VMX_EPTP_MT_WB | VMX_EPTP_PWL_4;
 	if (cpu_has_vmx_ept_ad_bits())
-		eptp |= VMX_EPT_AD_ENABLE_BIT;
+		eptp |= VMX_EPTP_AD_ENABLE_BIT;
 	eptp |= (root_hpa & PAGE_MASK);
 
 	return eptp;
@@ -1246,7 +1245,7 @@ static struct vmx_vcpu * vmx_create_vcpu(struct dune_config *conf)
 	vcpu->cpu = -1;
 	vcpu->syscall_tbl = (void *) &dune_syscall_tbl;
 
-	native_store_idt(&dt);
+	store_idt(&dt);
 	vcpu->idt_base = (void *)dt.address;
 
 	spin_lock_init(&vcpu->ept_lock);
@@ -1782,7 +1781,7 @@ static void vmx_handle_external_interrupt(struct vmx_vcpu *vcpu, u32 exit_intr_i
 		register unsigned long current_stack_pointer asm(_ASM_SP);
 		vector =  exit_intr_info & INTR_INFO_VECTOR_MASK;
 		desc = (gate_desc *)vcpu->idt_base + vector;
-		entry = gate_offset(*desc);
+		entry = gate_offset(desc);
 
 		if (vector == POSTED_INTR_VECTOR) {
 			dune_apic_write_eoi();


### PR DESCRIPTION
_Note_: definitely don't merge yet, this doesn't work.

Dune doesn't currently compile against Linux 4.14. I've made necessary changes to _compile_ the kernel, most of which seem generally straight forward. I'm adding comments in the PR diff.

The compiled module still won't load:

```
insmod: ERROR: could not insert module ./dune.ko: Unknown symbol in module
```

I haven't bothered to debug this yet since I'm not at all confident in my changes to the code just yet.

I've also just changed the code inline for now rather than add `#ifdef`s for the kernel version. I'll go back and clean it up once it works.

Would appreciate feedback from those who know the kernel interfaces (and what dune is trying to do with them) better than me.